### PR TITLE
Security: replace globals().get() with explicit function registry

### DIFF
--- a/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
+++ b/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
@@ -62,10 +62,27 @@
 # NB_FMD_CUSTOM_DQ_CLEANSING can register themselves via register_cleansing_function().
 _CLEANSING_FUNCTION_REGISTRY = {}
 
-def register_cleansing_function(name, func):
+def register_cleansing_function(name, func, overwrite=False):
     """Register a cleansing function by name so it can be invoked from metadata rules."""
-    _CLEANSING_FUNCTION_REGISTRY[name] = func
+    if not isinstance(name, str):
+        raise TypeError("Cleansing function name must be a string.")
 
+    normalized_name = name.strip()
+    if not normalized_name:
+        raise ValueError("Cleansing function name must be a non-empty string.")
+
+    if not callable(func):
+        raise TypeError(
+            f"Cleansing function '{normalized_name}' must be callable."
+        )
+
+    if not overwrite and normalized_name in _CLEANSING_FUNCTION_REGISTRY:
+        raise ValueError(
+            f"Cleansing function '{normalized_name}' is already registered. "
+            "Pass overwrite=True to replace the existing registration."
+        )
+
+    _CLEANSING_FUNCTION_REGISTRY[normalized_name] = func
 # METADATA ********************
 
 # META {

--- a/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
+++ b/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
@@ -117,10 +117,15 @@ def dynamic_call_cleansing_function(df: DataFrame,
         except Exception as e:
             raise ValueError(f"Function '{func_name}' failed with Error: {e}") from e
     else:
-        available = ", ".join(sorted(_CLEANSING_FUNCTION_REGISTRY.keys()))
+        available_functions = sorted(_CLEANSING_FUNCTION_REGISTRY.keys())
+        available_message = (
+            f"Available functions: {', '.join(available_functions)}"
+            if available_functions
+            else "No functions registered."
+        )
         raise ValueError(
             f"Function '{func_name}' is not a registered cleansing function. "
-            f"Available functions: {available}"
+            f"{available_message}"
         )
 
 # METADATA ********************

--- a/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
+++ b/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
@@ -115,7 +115,7 @@ def dynamic_call_cleansing_function(df: DataFrame,
         try:
             return func(df, columns, *args, **kwargs)
         except Exception as e:
-            raise ValueError(f"Function '{func_name}' failed with Error: {e}")
+            raise ValueError(f"Function '{func_name}' failed with Error: {e}") from e
     else:
         available = ", ".join(sorted(_CLEANSING_FUNCTION_REGISTRY.keys()))
         raise ValueError(

--- a/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
+++ b/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
@@ -39,21 +39,39 @@
 # 
 # 
 # ## Custom functions
-# 
-# Custom functions can be added in a separate notebook NB_FMD_CUSTOM_DQ_CLEANSING
-# 
+#
+# Custom functions can be added in a separate notebook NB_FMD_CUSTOM_DQ_CLEANSING.
+# Each function must be registered to be callable from cleansing rules:
+#
 # ```
-# def <functioname> (df, columns, args):
-# 
+# def my_custom_function(df, columns, args):
 #     print(args['<custom parameter name>']) # use of custom parameters
-# 
 #     for column in columns: # apply function foreach column
 #         df = df.<custom logic>
-# 
-#     return df #always return dataframe.
+#     return df # always return dataframe
+#
+# register_cleansing_function("my_custom_function", my_custom_function)
 # ```
 # 
 
+
+# CELL ********************
+
+# Registry of allowed cleansing functions.
+# Built-in functions are registered below; custom functions from
+# NB_FMD_CUSTOM_DQ_CLEANSING can register themselves via register_cleansing_function().
+_CLEANSING_FUNCTION_REGISTRY = {}
+
+def register_cleansing_function(name, func):
+    """Register a cleansing function by name so it can be invoked from metadata rules."""
+    _CLEANSING_FUNCTION_REGISTRY[name] = func
+
+# METADATA ********************
+
+# META {
+# META   "language": "python",
+# META   "language_group": "synapse_pyspark"
+# META }
 
 # CELL ********************
 
@@ -74,7 +92,7 @@ def dynamic_call_cleansing_function(df: DataFrame,
         *args, 
         **kwargs):
 
-    func = globals().get(func_name)
+    func = _CLEANSING_FUNCTION_REGISTRY.get(func_name)
 
     if func:
         try:
@@ -82,7 +100,11 @@ def dynamic_call_cleansing_function(df: DataFrame,
         except Exception as e:
             raise ValueError(f"Function '{func_name}' failed with Error: {e}")
     else:
-        raise ValueError(f"Function '{func_name}' not found")
+        available = ", ".join(sorted(_CLEANSING_FUNCTION_REGISTRY.keys()))
+        raise ValueError(
+            f"Function '{func_name}' is not a registered cleansing function. "
+            f"Available functions: {available}"
+        )
 
 # METADATA ********************
 
@@ -290,6 +312,13 @@ def parse_datetime(df: DataFrame, columns, args):
         if into and not keep_original and out_col != c:
             df = df.drop(c)
     return df
+
+# CELL ********************
+
+# Register built-in cleansing functions
+register_cleansing_function("normalize_text", normalize_text)
+register_cleansing_function("fill_nulls", fill_nulls)
+register_cleansing_function("parse_datetime", parse_datetime)
 
 # METADATA ********************
 


### PR DESCRIPTION
## Summary
- Replace `globals().get(func_name)` with `_CLEANSING_FUNCTION_REGISTRY.get(func_name)` in `NB_FMD_DQ_CLEANSING`
- Add `register_cleansing_function()` API for registering allowed cleansing functions
- Built-in functions (`normalize_text`, `fill_nulls`, `parse_datetime`) are auto-registered
- Custom functions from `NB_FMD_CUSTOM_DQ_CLEANSING` register via `register_cleansing_function()`
- Error messages now list all available registered functions

## Why
`globals().get(func_name)` allows execution of **any function** in the global namespace if the cleansing rules in the metadata database are compromised. An attacker could invoke `exec`, `eval`, `__import__`, or any imported module function, leading to arbitrary code execution on the Spark cluster.

The function registry pattern (allowlist) ensures only explicitly registered functions can be invoked from metadata rules.

## Migration for custom functions
If you have custom cleansing functions in `NB_FMD_CUSTOM_DQ_CLEANSING`, add a registration call:
```python
def my_custom_function(df, columns, args):
    # ... your logic ...
    return df

register_cleansing_function("my_custom_function", my_custom_function)
```

## Test plan
- [ ] Verify built-in cleansing functions (normalize_text, fill_nulls, parse_datetime) work as before
- [ ] Verify custom cleansing functions work after adding `register_cleansing_function()` call
- [ ] Verify unregistered function names produce a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)