### PR TITLE
Code quality: SHA-256, datetime, boolean checks, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Environment
+.env
+.env.*
+*.env
+
+# Sensitive files
+*secret*
+*credential*
+*.pem
+*.key
+
+# OS
+.DS_Store
+Thumbs.db
+
+# OMC (oh-my-claudecode)
+.omc/

--- a/src/NB_FMD_CUSTOM_NOTEBOOK_TEMPLATE.Notebook/notebook-content.py
+++ b/src/NB_FMD_CUSTOM_NOTEBOOK_TEMPLATE.Notebook/notebook-content.py
@@ -250,7 +250,7 @@ output_dataframe = sample_dataframe
 # CELL ********************
 
 # Ensure the existence of an output_dataframe
-if (not output_dataframe) or (type(output_dataframe) != DataFrame):
+if output_dataframe is None or not isinstance(output_dataframe, DataFrame):
     raise Exception("No output_dataframe defined, or output_dataframe not a spark dataframe.")
 
 # Write the output dataframe to Onelake

--- a/src/NB_FMD_LOAD_BRONZE_SILVER.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_BRONZE_SILVER.Notebook/notebook-content.py
@@ -105,7 +105,8 @@ import re
 from datetime import datetime, timezone
 import json
 from delta.tables import *
-from pyspark.sql.functions import sha2, concat_ws, StringType, current_timestamp, expr
+from pyspark.sql.functions import sha2, concat_ws, current_timestamp, expr
+from pyspark.sql.types import StringType
 
 
 # METADATA ********************

--- a/src/NB_FMD_LOAD_BRONZE_SILVER.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_BRONZE_SILVER.Notebook/notebook-content.py
@@ -105,7 +105,7 @@ import re
 from datetime import datetime, timezone
 import json
 from delta.tables import *
-from pyspark.sql.functions import sha2, concat_ws, md5, StringType,current_timestamp, expr
+from pyspark.sql.functions import sha2, concat_ws, StringType, current_timestamp, expr
 
 
 # METADATA ********************
@@ -164,7 +164,7 @@ token =  notebookutils.credentials.getToken('https://analysis.windows.net/powerb
 # CELL ********************
 
 # Ensure TriggerTime is formatted correctly
-TriggerTime = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+TriggerTime = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 notebook_name=  notebookutils.runtime.context['currentNotebookName']
 
 
@@ -266,21 +266,15 @@ spark.conf.set("spark.fabric.resourceProfile", "readHeavyForSpark")
 
 # CELL ********************
 
-#Set SourceFile and target Location
-if schema_enabled == True:
+#Set source and target data paths
+if str(schema_enabled).lower() == "true":
     source_changes_data_path = f"abfss://{SourceWorkspace}@onelake.dfs.fabric.microsoft.com/{SourceLakehouse}/Tables/{DataSourceNamespace}/{SourceSchema}_{SourceName}"
-    print(source_changes_data_path)
-
-    #Beware 
     target_data_path = f"abfss://{TargetWorkspace}@onelake.dfs.fabric.microsoft.com/{TargetLakehouse}/Tables/{DataSourceNamespace}/{TargetSchema}_{TargetName}"
-    print(target_data_path)
-elif schema_enabled  != True:
+else:
     source_changes_data_path = f"abfss://{SourceWorkspace}@onelake.dfs.fabric.microsoft.com/{SourceLakehouse}/Tables/{DataSourceNamespace}_{SourceSchema}_{SourceName}"
-    print(source_changes_data_path)
-
-    #Beware 
     target_data_path = f"abfss://{TargetWorkspace}@onelake.dfs.fabric.microsoft.com/{TargetLakehouse}/Tables/{DataSourceNamespace}_{TargetSchema}_{TargetName}"
-    print(target_data_path)
+print(source_changes_data_path)
+print(target_data_path)
 
 
 # METADATA ********************
@@ -376,7 +370,7 @@ non_key_columns = [column for column in dfDataChanged.columns if column not in (
 
 #add a hashed cloumn to detect changes
 
-dfDataChanged = dfDataChanged.withColumn("HashedNonKeyColumns", md5(concat_ws("||", *non_key_columns).cast(StringType())))
+dfDataChanged = dfDataChanged.withColumn("HashedNonKeyColumns", sha2(concat_ws("||", *non_key_columns).cast(StringType()), 256))
 
 # METADATA ********************
 

--- a/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
@@ -113,7 +113,8 @@ import re
 from datetime import datetime, timezone
 import json
 from delta.tables import *
-from pyspark.sql.functions import sha2, concat_ws, StringType, current_timestamp
+from pyspark.sql.functions import sha2, concat_ws, current_timestamp
+from pyspark.sql.types import StringType
 
 # METADATA ********************
 

--- a/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
@@ -113,7 +113,7 @@ import re
 from datetime import datetime, timezone
 import json
 from delta.tables import *
-from pyspark.sql.functions import sha2, concat_ws, md5, StringType,current_timestamp
+from pyspark.sql.functions import sha2, concat_ws, StringType, current_timestamp
 
 # METADATA ********************
 
@@ -171,7 +171,7 @@ token =  notebookutils.credentials.getToken('https://analysis.windows.net/powerb
 # CELL ********************
 
 # Ensure TriggerTime is formatted correctly
-TriggerTime = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+TriggerTime = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 notebook_name=  notebookutils.runtime.context['currentNotebookName']
 
 
@@ -283,22 +283,14 @@ spark.conf.set("spark.fabric.resourceProfile", "writeHeavy")
 # CELL ********************
 
 #Set SourceFile and target Location
-if schema_enabled == True:
-    #Set SourceFile and target Location
-    source_changes_data_path = f"abfss://{SourceWorkspace}@onelake.dfs.fabric.microsoft.com/{SourceLakehouse}/Files/{SourceFilePath}/{SourceFileName}"
-    print(source_changes_data_path)
+source_changes_data_path = f"abfss://{SourceWorkspace}@onelake.dfs.fabric.microsoft.com/{SourceLakehouse}/Files/{SourceFilePath}/{SourceFileName}"
+print(source_changes_data_path)
 
-    #Beware 
+if str(schema_enabled).lower() == "true":
     target_data_path = f"abfss://{TargetWorkspace}@onelake.dfs.fabric.microsoft.com/{TargetLakehouse}/Tables/{DataSourceNamespace}/{TargetSchema}_{TargetName}"
-    print(target_data_path)
-elif schema_enabled != True:
-    #Set SourceFile and target Location
-    source_changes_data_path = f"abfss://{SourceWorkspace}@onelake.dfs.fabric.microsoft.com/{SourceLakehouse}/Files/{SourceFilePath}/{SourceFileName}"
-    print(source_changes_data_path)
-
-    #Beware 
+else:
     target_data_path = f"abfss://{TargetWorkspace}@onelake.dfs.fabric.microsoft.com/{TargetLakehouse}/Tables/{DataSourceNamespace}_{TargetSchema}_{TargetName}"
-    print(target_data_path)
+print(target_data_path)
 
 
 # METADATA ********************
@@ -441,7 +433,8 @@ dfDataChanged = (dfDataChanged
 
 # CELL ********************
 
-if dfDataChanged.select('HashedPKColumn').distinct().count() != dfDataChanged.select('HashedPKColumn').count():
+dup_count = dfDataChanged.groupBy('HashedPKColumn').count().where('count > 1').limit(1).collect()
+if dup_count:
     raise ValueError(f'Source file contains duplicated rows for PK: {", ".join(key_columns)}')
 
 # METADATA ********************
@@ -515,7 +508,7 @@ dfDataChanged=handle_cleansing_functions(dfDataChanged,cleansing_rules)
 non_key_columns = [column for column in dfDataChanged.columns if column not in key_columns]
 
 #add a hashed cloumn to detect changes
-dfDataChanged = dfDataChanged.withColumn("HashedNonKeyColumns", md5(concat_ws("||", *non_key_columns).cast(StringType())))
+dfDataChanged = dfDataChanged.withColumn("HashedNonKeyColumns", sha2(concat_ws("||", *non_key_columns).cast(StringType()), 256))
 
 #Add RecordLoadDate to see when the record arrived
 dfDataChanged = dfDataChanged.withColumn('RecordLoadDate', current_timestamp())


### PR DESCRIPTION
## Summary
- **Add `.gitignore`** to prevent accidental commits of secrets, IDE files, and Python artifacts
- **Replace deprecated `datetime.utcnow()`** with `datetime.now(timezone.utc)` in `NB_FMD_LOAD_LANDING_BRONZE` and `NB_FMD_LOAD_BRONZE_SILVER` (deprecated since Python 3.12, already correct in `NB_FMD_CUSTOM_NOTEBOOK_TEMPLATE`)
- **Use SHA-256 consistently** for `HashedNonKeyColumns` — was using MD5 while `HashedPKColumn` already used SHA-256. Removes `md5` import.
- **Fix `schema_enabled` boolean comparison** — `schema_enabled == True` fails when the Variable Library returns the string `"True"`. Changed to `str(schema_enabled).lower() == "true"`. Also consolidated duplicated source path construction.
- **Optimize duplicate PK detection** from two full table scans to a single `groupBy` pass
- **Fix DataFrame type check** in `NB_FMD_CUSTOM_NOTEBOOK_TEMPLATE` — `type(x) != DataFrame` → `isinstance()`; `not output_dataframe` → `output_dataframe is None`

## Impact
**Breaking change note:** The `HashedNonKeyColumns` hash algorithm changes from MD5 to SHA-256. Existing Bronze and Silver tables have MD5 hashes stored. On the next run:
- **Bronze:** The merge uses `HashedPKColumn` (already SHA-256) for matching, so the merge key is unaffected. `HashedNonKeyColumns` is used for change detection — the new SHA-256 hash will differ from the stored MD5 hash, causing all rows to be detected as "changed" on the first run after this update. This is a one-time full update, after which incremental detection resumes normally.
- **Silver:** Same behavior — one-time full SCD2 update cycle.

## Test plan
- [ ] Verify `.gitignore` excludes expected patterns
- [ ] Run a full pipeline and verify `TriggerTime` timestamps are correct
- [ ] Verify first run after hash change completes (expect full update cycle)
- [ ] Verify subsequent runs detect only actual changes
- [ ] Test with `lakehouse_schema_enabled` set to both `True` (boolean) and `"True"` (string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)