### PR TITLE
Bronze: exclude the primary key columns from HashedNonKeyColumns

### DIFF
--- a/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
@@ -506,7 +506,7 @@ dfDataChanged=handle_cleansing_functions(dfDataChanged,cleansing_rules)
 
 # CELL ********************
 
-non_key_columns = [column for column in dfDataChanged.columns if column not in (key_columns, 'HashedPKColumn')]
+non_key_columns = [column for column in dfDataChanged.columns if column not in key_columns and column != 'HashedPKColumn']
 
 #add a hashed cloumn to detect changes
 dfDataChanged = dfDataChanged.withColumn("HashedNonKeyColumns", md5(concat_ws("||", *non_key_columns).cast(StringType())))


### PR DESCRIPTION
In `NB_FMD_LOAD_LANDING_BRONZE`, the membership test that builds `non_key_columns` puts a **list** inside a tuple:

```python
non_key_columns = [column for column in dfDataChanged.columns
                   if column not in (key_columns, "HashedPKColumn")]
```

`key_columns` is a list, and a column name is never equal to a list, so the only thing that check actually excludes is the literal string `HashedPKColumn`. **The primary key columns end up inside `HashedNonKeyColumns`.**

Reproduced in plain Python:

```python
columns     = ["CustomerId", "FirstName", "LastName", "HashedPKColumn"]
key_columns = ["CustomerId"]

[c for c in columns if c not in (key_columns, "HashedPKColumn")]
# -> ["CustomerId", "FirstName", "LastName"]      the PK is still there

[c for c in columns if c not in key_columns and c != "HashedPKColumn"]
# -> ["FirstName", "LastName"]                    intended
```

This is the same defect as #234 (from discussion #233), which you fixed in `NB_FMD_LOAD_BRONZE_SILVER`. The Bronze notebook still carries it.

**Observed consequence.** In a deployment of the framework at `1ba7974` against a live Fabric tenant, `HashedNonKeyColumns` differs between Bronze and Silver for the same row, because the two notebooks hash over different column sets:

```
Bronze:  ecad8cf690e2a77ae940a21f70...
Silver:  518ad97555916eae2bb0ef0128...
```

Change detection still works, since a primary key does not change within a row, so this is a correctness-of-intent issue rather than a data-loss one. The fix is the one line.