### PR TITLE
Cleansing: default parameters to an empty dict, so a rule without them does not raise

### DIFF
--- a/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
+++ b/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
@@ -181,7 +181,7 @@ def handle_cleansing_functions(df: DataFrame, cleansing_rules):
             print(f"'function' missing in: {rule}")
             continue
 
-        parameters = rule.get("parameters")
+        parameters = rule.get("parameters") or {}
         columns_raw = rule.get("columns")
 
         columns = (

--- a/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
+++ b/src/NB_FMD_DQ_CLEANSING.Notebook/notebook-content.py
@@ -181,7 +181,13 @@ def handle_cleansing_functions(df: DataFrame, cleansing_rules):
             print(f"'function' missing in: {rule}")
             continue
 
-        parameters = rule.get("parameters") or {}
+        parameters = rule.get("parameters")
+        if parameters is None:
+            parameters = {}
+        elif not isinstance(parameters, dict):
+            raise TypeError(
+                f"'parameters' must be a dict for function '{function}' (got {type(parameters).__name__})"
+            )
         columns_raw = rule.get("columns")
 
         columns = (


### PR DESCRIPTION
A cleansing rule that omits `"parameters"` fails at run time, even though the key looks optional.

`handle_cleansing_functions` reads it with `rule.get("parameters")`, which yields `None` when the key is absent, and passes that `None` **positionally** into the function. Every built-in has the signature `f(df, columns, args)` with `args` positional and no default, and every one of them starts with `args.get(...)`.

Reproducing the dispatch chain exactly, minus Spark:

```python
rule = [{"function": "normalize_text", "columns": "TransactionTypeName"}]
handle_cleansing_functions(df, rule)

# ValueError: Function normalize_text failed with Error:
#            NoneType object has no attribute get
```

All three built-ins (`normalize_text`, `fill_nulls`, `parse_datetime`) treat every key inside `args` as optional, so an empty dict is the correct default and none of them needs to change. One line:

```python
parameters = rule.get("parameters") or {}
```

With this, a rule can be written the way the format suggests:

```json
{ "function": "normalize_text", "columns": "TransactionTypeName" }
```

Found while documenting the cleansing framework and writing an example that then would not run.