### PR TITLE
Setup: replace the author's tenant identifiers with placeholders

### DIFF
--- a/setup/NB_SETUP_FMD.ipynb
+++ b/setup/NB_SETUP_FMD.ipynb
@@ -141,9 +141,9 @@
    "source": [
     "reassign_capacity= True                                         # If set to False existing assigned capacities to workspaces will no be overwritten\n",
     "\n",
-    "capacity_name_dvlm = \"Trial-Erwin\"                              # Which capacity will be used for these workspaces in development\n",
-    "capacity_name_prod = 'Trial-Erwin'                              # Which capacity will be used for these workspaces in production\n",
-    "capacity_name_config = 'Trial-Erwin'                      # Which capacity will be used for this workspace for the Metadata Database"
+    "capacity_name_dvlm = '<your capacity name>'                              # Which capacity will be used for these workspaces in development\n",
+    "capacity_name_prod = '<your capacity name>'                              # Which capacity will be used for these workspaces in production\n",
+    "capacity_name_config = '<your capacity name>'                      # Which capacity will be used for this workspace for the Metadata Database"
    ]
   },
   {
@@ -185,7 +185,7 @@
     "\n",
     "domain_name='INTEGRATION'                           # Main Domain for Integration for example INTEGRATION CODE(D) \n",
     "\n",
-    "domain_contributor_role = {\"type\": \"Contributors\",\"principals\": [{\"id\": \"86897900-8de5-4894-ae41-1b4d1642acda\",\"type\": \"Group\"}  ]}  # Which group(Object ID) can add or remove workspaces to this domain\n",
+    "domain_contributor_role = {\"type\": \"Contributors\",\"principals\": [{\"id\": \"00000000-0000-0000-0000-000000000000\",\"type\": \"Group\"}  ]}  # Which group(Object ID) can add or remove workspaces to this domain\n",
     "\n",
     "##Connections\n",
     "connection_fabric_datapipelines_name='CON_FMD_FABRIC_PIPELINES'\n",
@@ -193,7 +193,7 @@
     "connection_fabric_database_name='CON_FMD_FABRIC_SQL'\n",
     "connection_fabric_adf_name='CON_FMD_ADF_PIPELINES'\n",
     "\n",
-    "connection_role =  {\"role\": \"owner\",\"principals\": [{\"id\": \"86897900-8de5-4894-ae41-1b4d1642acda\",\"type\": \"Group\"}  ]}  # Which group(Object ID) can add or remove workspaces to this domain\n"
+    "connection_role =  {\"role\": \"owner\",\"principals\": [{\"id\": \"00000000-0000-0000-0000-000000000000\",\"type\": \"Group\"}  ]}  # Which group(Object ID) can add or remove workspaces to this domain\n"
    ]
   },
   {
@@ -286,14 +286,14 @@
     "workspace_roles_code = [ # Keep emtpy [] if you only want to assign this to your personal account\n",
     "                                        {\n",
     "                       \"principal\": {\n",
-    "                            \"id\": '86897900-8de5-4894-ae41-1b4d1642acda',\n",
+    "                            \"id\": '00000000-0000-0000-0000-000000000000',\n",
     "                            \"type\": \"Group\"\n",
     "                        },\n",
     "                        \"role\": \"admin\"  #(choose from 'admin', 'member', 'contributor', 'viewer')\n",
     "                        },\n",
     "                        {\n",
     "                       \"principal\": {\n",
-    "                            \"id\": 'b0bf9847-5b7a-4560-947b-b149f71d303b',\n",
+    "                            \"id\": '00000000-0000-0000-0000-000000000000',\n",
     "                            \"type\": \"ServicePrincipal\"\n",
     "                        },\n",
     "                        \"role\": \"contributor\"  #(choose from 'admin', 'member', 'contributor', 'viewer')\n",
@@ -302,21 +302,21 @@
     "workspace_roles_data =  [ # Keep emtpy [] if you only want to assign this to your personal account\n",
     "                                        {\n",
     "                       \"principal\": {\n",
-    "                            \"id\": '86897900-8de5-4894-ae41-1b4d1642acda',\n",
+    "                            \"id\": '00000000-0000-0000-0000-000000000000',\n",
     "                            \"type\": \"Group\"\n",
     "                        },\n",
     "                        \"role\": \"admin\"  #(choose from 'admin', 'member', 'contributor', 'viewer')\n",
     "                        },    \n",
     "                         {\n",
     "                       \"principal\": {\n",
-    "                            \"id\": '5c906b5c-d1d7-4984-b047-adacd8d795fe',\n",
+    "                            \"id\": '00000000-0000-0000-0000-000000000000',\n",
     "                            \"type\": \"Group\"\n",
     "                        },\n",
     "                        \"role\": \"contributor\"  #(choose from 'admin', 'member', 'contributor', 'viewer')\n",
     "                        },\n",
     "                        {\n",
     "                       \"principal\": {\n",
-    "                            \"id\": 'b0bf9847-5b7a-4560-947b-b149f71d303b',\n",
+    "                            \"id\": '00000000-0000-0000-0000-000000000000',\n",
     "                            \"type\": \"ServicePrincipal\"\n",
     "                        },\n",
     "                        \"role\": \"contributor\"  #(choose from 'admin', 'member', 'contributor', 'viewer')\n",

--- a/setup/NB_SETUP_FMD.ipynb
+++ b/setup/NB_SETUP_FMD.ipynb
@@ -193,7 +193,7 @@
     "connection_fabric_database_name='CON_FMD_FABRIC_SQL'\n",
     "connection_fabric_adf_name='CON_FMD_ADF_PIPELINES'\n",
     "\n",
-    "connection_role =  {\"role\": \"owner\",\"principals\": [{\"id\": \"00000000-0000-0000-0000-000000000000\",\"type\": \"Group\"}  ]}  # Which group(Object ID) can add or remove workspaces to this domain\n"
+    "connection_role =  {\"role\": \"owner\",\"principals\": [{\"id\": \"00000000-0000-0000-0000-000000000000\",\"type\": \"Group\"}]}  # Which principal(s) will be set as owner for the created connections\n"
    ]
   },
   {


### PR DESCRIPTION
`NB_SETUP_FMD.ipynb` ships with values that only resolve in your own tenant. A first-time deployer has to find and change every one of them, and the deployment guide does not mention any of them.

| Cell | Value |
|---|---|
| 7 | `capacity_name_dvlm` / `_prod` / `_config` = `Trial-Erwin` |
| 9 | `domain_contributor_role` and `connection_role`, one group object ID |
| 14 | `workspace_roles_code` and `workspace_roles_data`, two groups and one service principal |

This PR replaces them with the same `00000000-0000-0000-0000-000000000000` placeholder that `FMD_FRAMEWORK_DEPLOYMENT.md` already uses in its own examples, and the capacity with `<your capacity name>`. An unedited value then fails visibly, instead of pointing at a tenant the deployer has never heard of.

Nothing else in the notebook changes. 10 lines, and it still parses as a valid notebook (76 cells).

**Note on #244.** I have not reproduced that specific `RuntimeError`, so I am not claiming this fixes it. What I can say is that when I deployed the framework at `1ba7974` against a live Fabric tenant, the only way to get the workspace-creation cells to succeed was to set

```python
workspace_roles_code          = []
workspace_roles_data          = []
workspace_roles_configuration = []
```

which is what cell 14 own comment suggests for a personal deployment. Leaving the shipped principals in place means assigning roles to objects that do not exist in the deployer tenant.