### PR TITLE
Create CON_FMD_FABRIC_SQL automatically with a service principal

### DIFF
--- a/setup/NB_SETUP_FMD.ipynb
+++ b/setup/NB_SETUP_FMD.ipynb
@@ -193,6 +193,16 @@
     "connection_fabric_database_name='CON_FMD_FABRIC_SQL'\n",
     "connection_fabric_adf_name='CON_FMD_ADF_PIPELINES'\n",
     "\n",
+    "##Service principal used to create CON_FMD_FABRIC_SQL automatically.\n",
+    "##Leave these empty to keep the manual step. FabricSql accepts only OAuth2-family\n",
+    "##credentials, so a WorkspaceIdentity cannot be used here, but a service principal can.\n",
+    "##The principal needs access to the CONFIG workspace that holds the database.\n",
+    "##Prefer a Key Vault reference over a literal secret, for example:\n",
+    "##  fabric_sql_sp_secret = notebookutils.credentials.getSecret(key_vault_uri_name, 'fmd-sp-secret')\n",
+    "fabric_sql_sp_tenant_id = ''\n",
+    "fabric_sql_sp_client_id = ''\n",
+    "fabric_sql_sp_secret    = ''\n",
+    "\n",
     "connection_role =  {\"role\": \"owner\",\"principals\": [{\"id\": \"00000000-0000-0000-0000-000000000000\",\"type\": \"Group\"}]}  # Which principal(s) will be set as owner for the created connections\n"
    ]
   },

--- a/src/NB_UTILITIES_SETUP_FMD.Notebook/notebook-content.py
+++ b/src/NB_UTILITIES_SETUP_FMD.Notebook/notebook-content.py
@@ -701,6 +701,62 @@ def get_existing_connections_by_id():
     return connection_list
 
 
+def create_fabric_sql_connection(connection_name, tenant_id, client_id, client_secret):
+    """Create a FabricSql connection through the Fabric REST API.
+
+    The fab CLI cannot create this one, which is why it used to be a manual step.
+    Two things make it work:
+
+      * creationMethod must be 'FabricSql.Contents'. The supported creation
+        methods are listed by GET /v1/connections/supportedConnectionTypes.
+      * FabricSql accepts only OAuth2-family credentials. WorkspaceIdentity is
+        rejected with UnsupportedCredentialType. A service principal is accepted,
+        because a service principal is a way of obtaining an OAuth2 token.
+
+    The service principal must have access to the workspace that holds the
+    database, otherwise the connector reports
+    'No workspaces are available for the current account'.
+    """
+    payload = {
+        "connectivityType": "ShareableCloud",
+        "displayName": connection_name,
+        "connectionDetails": {
+            "type": "FabricSql",
+            "creationMethod": "FabricSql.Contents",
+            "parameters": []
+        },
+        "privacyLevel": "Organizational",
+        "credentialDetails": {
+            "singleSignOnType": "None",
+            "connectionEncryption": "NotEncrypted",
+            "skipTestConnection": False,
+            "credentials": {
+                "credentialType": "ServicePrincipal",
+                "tenantId": tenant_id,
+                "servicePrincipalClientId": client_id,
+                "servicePrincipalSecret": client_secret
+            }
+        }
+    }
+    headers = {
+        "Authorization": "Bearer " + notebookutils.credentials.getToken("pbi"),
+        "Content-Type": "application/json"
+    }
+    response = requests.post("https://api.fabric.microsoft.com/v1/connections",
+                             headers=headers, json=payload, timeout=120)
+    if response.status_code in (200, 201):
+        print(f"\u2705 {connection_name} Created")
+        return response.json().get("id")
+
+    # Never print the response body: it echoes the request, secret included.
+    error_code = ""
+    try:
+        error_code = response.json().get("errorCode", "")
+    except Exception:
+        pass
+    print(f"\u274c Failed to create {connection_name}: HTTP {response.status_code} {error_code}")
+    return None
+
 def create_or_get_fmd_connection(connection_name,connection_role, type):
     """
     Ensures the workspace exists; creates it if not found.
@@ -710,7 +766,14 @@ def create_or_get_fmd_connection(connection_name,connection_role, type):
     if ConnectionExists != "* true":
         try:
             if type =='FabricSql':
-                print("FabricSql can't created automated yet to CLI limitations, please create manual")
+                if fabric_sql_sp_tenant_id and fabric_sql_sp_client_id and fabric_sql_sp_secret:
+                    create_fabric_sql_connection(connection_name,
+                                                 fabric_sql_sp_tenant_id,
+                                                 fabric_sql_sp_client_id,
+                                                 fabric_sql_sp_secret)
+                else:
+                    print("FabricSql needs a service principal to be created automatically. "
+                          "Set fabric_sql_sp_tenant_id / _client_id / _secret, or create it manually.")
             elif type =='AzureDataFactory':
                 print("AzureDataFactory can't created automated yet to CLI limitations, please create manual")
             elif type =='FabricDataPipelines':

--- a/src/NB_UTILITIES_SETUP_FMD.Notebook/notebook-content.py
+++ b/src/NB_UTILITIES_SETUP_FMD.Notebook/notebook-content.py
@@ -742,19 +742,35 @@ def create_fabric_sql_connection(connection_name, tenant_id, client_id, client_s
         "Authorization": "Bearer " + notebookutils.credentials.getToken("pbi"),
         "Content-Type": "application/json"
     }
-    response = requests.post("https://api.fabric.microsoft.com/v1/connections",
-                             headers=headers, json=payload, timeout=120)
-    if response.status_code in (200, 201):
-        print(f"\u2705 {connection_name} Created")
-        return response.json().get("id")
-
-    # Never print the response body: it echoes the request, secret included.
+    # A client secret created moments ago is not immediately usable: Entra has not
+    # propagated it yet, and Fabric answers DMTS_OAuthTokenRefreshFailedError. That
+    # is a timing problem, not a wrong secret, so retry before giving up. Observed:
+    # the first call failed and the next one, ~15 seconds later, succeeded.
     error_code = ""
-    try:
-        error_code = response.json().get("errorCode", "")
-    except Exception:
-        pass
+    for attempt in range(4):
+        response = requests.post("https://api.fabric.microsoft.com/v1/connections",
+                                 headers=headers, json=payload, timeout=120)
+        if response.status_code in (200, 201):
+            print(f"\u2705 {connection_name} Created")
+            return response.json().get("id")
+
+        # Never print the response body: it echoes the request, secret included.
+        error_code = ""
+        try:
+            error_code = response.json().get("errorCode", "")
+        except Exception:
+            pass
+
+        if error_code != "DMTS_OAuthTokenRefreshFailedError" or attempt == 3:
+            break
+        print(f"   {connection_name}: credential not usable yet, retrying in 15s "
+              f"(attempt {attempt + 1} of 4)")
+        time.sleep(15)
+
     print(f"\u274c Failed to create {connection_name}: HTTP {response.status_code} {error_code}")
+    if error_code == "DMTS_OAuthTokenRefreshFailedError":
+        print("   The secret was rejected. Check that it is the secret VALUE and not the "
+              "secret ID, and that the principal has access to the workspace holding the database.")
     return None
 
 def create_or_get_fmd_connection(connection_name,connection_role, type):


### PR DESCRIPTION
The `FabricSql` connection is the one the setup cannot create, so it prints a message and moves on:

```python
if type == "FabricSql":
    print("FabricSql can't created automated yet to CLI limitations, please create manual")
```

**That is worse than a missing connection.** Every audit activity in every pipeline points at it. With nothing to point at, the deployment writes the CLI's error string into the connection field:

```json
"externalReferences": {
  "connection": "x get: [NotFound] The Connection 'CON_FMD_FABRIC_SQL.Connection' could not be found"
}
```

Fabric sees an invalid reference and quietly deactivates the activity:

```json
"state": "Inactive",
"onInactiveMarkAs": "Succeeded"
```

In `src/` those same activities are `Active`. So a deployment that reports success after ~36 minutes leaves every audit activity switched off and reporting success, and `logging` never receives a row. Nothing fails, nothing warns.

## It can be automated

Two things make it work. Both verified against a live tenant on 2026-07-13.

**1. The creation method is `FabricSql.Contents`, not `FabricSql`.** `GET /v1/connections/supportedConnectionTypes?showAllCreationMethods=true` answers:

```
=== FabricSql ===
supportedCredentialTypes: ["OAuth2"]
creationMethod: FabricSql.Contents
```

**2. `FabricSql` takes OAuth2-family credentials, and a service principal is one.** `WorkspaceIdentity`, which works for `FabricDataPipelines` and `Notebook`, is rejected here:

```
errorCode: UnsupportedCredentialType
```

A service principal is accepted, because a service principal is a way of obtaining an OAuth2 token. It must have access to the workspace holding the database, or the connector answers `No workspaces are available for the current account`. With a real principal and workspace access, `POST /v1/connections` returns `201` and `credentialType: ServicePrincipal`.

## What this PR does

Adds `create_fabric_sql_connection()` to `NB_UTILITIES_SETUP_FMD`, wired into the existing `FabricSql` branch of `create_or_get_fmd_connection`, and three settings in `NB_SETUP_FMD` cell 9:

```python
fabric_sql_sp_tenant_id = ""
fabric_sql_sp_client_id = ""
fabric_sql_sp_secret    = ""
```

**Opt-in and backwards compatible.** Leave them empty and the behaviour is unchanged, except the message now names what is missing rather than saying it is impossible. The comment points at `notebookutils.credentials.getSecret` so the secret can come from the Key Vault the notebook already has settings for. The response body is never printed, because it echoes the request, secret included.

The deployment guide already requires a service principal and the tenant setting *"Service principals can create workspaces, **connections**, and deployment pipelines"*, so the pieces are already in place.

Found while deploying the framework at `1ba7974` end to end and writing it up.