### PR TITLE
Define invoke_fabric_api_request, which is called but never exists

### DIFF
--- a/src/NB_UTILITIES_SETUP_FMD.Notebook/notebook-content.py
+++ b/src/NB_UTILITIES_SETUP_FMD.Notebook/notebook-content.py
@@ -747,6 +747,28 @@ def create_or_get_fmd_connection(connection_name,connection_role, type):
 # Workspace Handling for Cluster Request
 # -------------------------------
 
+FABRIC_API_BASE_URL = "https://api.fabric.microsoft.com/v1/"
+
+def invoke_fabric_api_request(method, path, payload=None):
+    """Call the Fabric public REST API with a path relative to /v1/.
+
+    invoke_fabric_request() polls long running operations through this helper, but
+    it was referenced without ever being defined, so reaching the 202 branch raised
+    NameError: name 'invoke_fabric_api_request' is not defined.
+
+    Deliberately does not handle 202 itself, so that it cannot recurse into the
+    poller that calls it.
+    """
+    headers = {
+        "Authorization": "Bearer " + notebookutils.credentials.getToken("pbi"),
+        "Content-Type": "application/json"
+    }
+    return requests.request(method,
+                            FABRIC_API_BASE_URL + path.lstrip("/"),
+                            headers=headers,
+                            json=payload,
+                            timeout=240)
+
 def invoke_fabric_request(method, url, payload=None):
     
     headers = {


### PR DESCRIPTION
`invoke_fabric_request()` polls long-running operations through `invoke_fabric_api_request()`:

```python
if (response.status_code == 202):
    operation_id = response.headers.get("x-ms-operation-id")
    while True:
        operation_state_response = invoke_fabric_api_request("get", f"operations/{operation_id}")   # line 833
        ...
            response = invoke_fabric_api_request("get", f"operations/{operation_id}/result")        # line 839
```

`invoke_fabric_api_request` is **defined nowhere in the repository**. `grep -rn "def invoke_fabric_api_request"` returns nothing. Any response that comes back `202` therefore raises

```
NameError: name 'invoke_fabric_api_request' is not defined
```

instead of polling. It has not surfaced yet because the cluster-metadata calls that go through the poller have so far returned `200`.

## What the missing function was

The two call sites pass a path **relative** to the Fabric public API (`operations/{id}`), while `invoke_fabric_request` takes a **full** URL (`f"{cluster_base_url}metadata/folders/{workspace_id}"`). So the missing helper was one against `https://api.fabric.microsoft.com/v1/`. This PR adds exactly that, in the same style as the existing helper, and deliberately **without** its own `202` handling, so that it cannot recurse into the poller that calls it.

Found while reading the setup utilities to write up the deployment.