### PR TITLE
PL_FMD_LOAD_ALL: report failure instead of reporting success

### DIFF
--- a/src/PL_FMD_LOAD_ALL.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_ALL.DataPipeline/pipeline-content.json
@@ -695,6 +695,12 @@
             "dependencyConditions": [
               "Completed"
             ]
+          },
+          {
+            "activity": "PL_FMD_LOAD_SILVER",
+            "dependencyConditions": [
+              "Completed"
+            ]
           }
         ]
       },

--- a/src/PL_FMD_LOAD_ALL.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_ALL.DataPipeline/pipeline-content.json
@@ -681,6 +681,54 @@
             ]
           }
         ]
+      },
+      {
+        "type": "Fail",
+        "typeProperties": {
+          "message": "The Landingzone layer failed. The failure is already recorded in logging.PipelineExecution; query it for the failing entity.",
+          "errorCode": "LandingzoneFailed"
+        },
+        "name": "FA_THROW_ERROR_LDZ",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_LDZ_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Fail",
+        "typeProperties": {
+          "message": "The Bronze layer failed. The failure is already recorded in logging.PipelineExecution; query it for the failing entity.",
+          "errorCode": "BronzeFailed"
+        },
+        "name": "FA_THROW_ERROR_BRZ",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_BRZ_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "Fail",
+        "typeProperties": {
+          "message": "The Silver layer failed. The failure is already recorded in logging.PipelineExecution; query it for the failing entity.",
+          "errorCode": "SilverFailed"
+        },
+        "name": "FA_THROW_ERROR_SLV",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_SLV_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ]
       }
     ],
     "parameters": {


### PR DESCRIPTION
`PL_FMD_LOAD_ALL` contains **no `Fail` activity**. Every failure path is an *Upon Failure* branch to a stored procedure that logs and then succeeds:

| Activity | dependsOn |
|---|---|
| `PL_FMD_LOAD_LANDINGZONE` | `SP_START_AUDIT_PIPELINE: Succeeded` |
| `SP_FAIL_LDZ_AUDIT_PIPELINE` | `PL_FMD_LOAD_LANDINGZONE: Failed` |
| `PL_FMD_LOAD_BRONZE` | `PL_FMD_LOAD_LANDINGZONE: Completed` |
| `SP_FAIL_BRZ_AUDIT_PIPELINE` | `PL_FMD_LOAD_BRONZE: Failed` |
| `PL_FMD_LOAD_SILVER` | `PL_FMD_LOAD_BRONZE: Completed` |
| `SP_FAIL_SLV_AUDIT_PIPELINE` | `PL_FMD_LOAD_SILVER: Failed` |
| `SP_END_AUDIT_PIPELINE` | `PL_FMD_LOAD_SILVER: Succeeded` |

That is the **Try-Catch** shape, and Microsoft documents the consequence in a table with no ambiguity:

> | Approach | Defines | When activity **fails**, overall pipeline shows |
> |---|---|---|
> | Try-Catch | Only *Upon Failure* path | **Success** |
>
> *Pipeline result is success if and only if all nodes evaluated succeed.*
>
> [Errors and conditional execution](https://learn.microsoft.com/azure/data-factory/tutorial-pipeline-failure-error-handling#error-handling)

The catch branches are leaves, and they succeed.

## Observed

Deploying the framework at `1ba7974` against a live Fabric tenant and running `PL_FMD_LOAD_ALL`:

```
06:11:54  PL_FMD_LDZ_COPY_FROM_ONELAKE_TABLES_01   StartPipeline
06:13:02  PL_FMD_LDZ_COPY_FROM_ONELAKE_TABLES_01   FailedPipeline
06:19:38  PL_FMD_LOAD_ALL      FailedPipeline   {"Action":"Error","Message":"BRZ failed"}
06:20:11  PL_FMD_LOAD_BRONZE   EndPipeline      (empty queue)
06:21:45  PL_FMD_LOAD_SILVER   EndPipeline      (empty queue)
06:22:29  PL_FMD_LOAD_ALL      EndPipeline      {"Action":"End"}
```

The copy failed. Nothing was loaded. Both queues stayed empty. The framework even logged `BRZ failed` itself. **And the Fabric job status was `Completed`.**

Anyone alerting on the run status of the pipeline they schedule is never told. `PL_FMD_LOAD_BRONZE` does go red, because it ends in `FA_THROW_ERROR`. The one you actually schedule does not.

## This PR

Adds three `Fail` activities, one per catch branch, mirroring `FA_THROW_ERROR` in `PL_FMD_LOAD_BRONZE`:

```
SP_FAIL_LDZ_AUDIT_PIPELINE --Completed--> FA_THROW_ERROR_LDZ
SP_FAIL_BRZ_AUDIT_PIPELINE --Completed--> FA_THROW_ERROR_BRZ
SP_FAIL_SLV_AUDIT_PIPELINE --Completed--> FA_THROW_ERROR_SLV
```

**The continue-on-failure behaviour is preserved.** The layer pipelines still depend on `Completed` rather than `Succeeded`, so a failing layer still does not block the others, which I take to be deliberate. Only the reported outcome changes.