### PR TITLE
Give NotebookExecution a usable PipelineParentRunGuid

### DIFF
--- a/src/NB_FMD_PROCESSING_PARALLEL_MAIN.Notebook/notebook-content.py
+++ b/src/NB_FMD_PROCESSING_PARALLEL_MAIN.Notebook/notebook-content.py
@@ -58,6 +58,7 @@ NotebookExecutionId = str(uuid.uuid4())
 Path = ""
 useRootDefaultLakehouse= True
 PipelineRunGuid = ""
+PipelineParentRunGuid = ""
 PipelineGuid = ""
 TriggerGuid = ""
 TriggerTime = ""
@@ -155,8 +156,16 @@ def batched(lst, first_size, default_size):
 PipelineName = notebookutils.runtime.context.get('currentNotebookName')
 PipelineGuid = str(notebookutils.runtime.context.get('currentNotebookId'))
 WorkspaceGuid = notebookutils.runtime.context.get('currentWorkspaceId')
-PipelineParentRunGuid = notebookutils.runtime.context.get('PipelineParentRunGuid')
-PipelineRunGuid = str(uuid.uuid4())
+# The two run ids come from the pipeline as parameters. notebookutils.runtime.context
+# has no key named PipelineParentRunGuid: Microsoft's property table for it lists 25
+# properties and this is not one of them, so the .get() below always returned None and
+# the fallback always fired, leaving 00000000-0000-0000-0000-000000000000 in every
+# logging.NotebookExecution row. Falling back to a fresh uuid4 for PipelineRunGuid keeps
+# a batch id when the notebook is run interactively.
+if not PipelineParentRunGuid:
+    PipelineParentRunGuid = notebookutils.runtime.context.get('PipelineParentRunGuid')
+if not PipelineRunGuid:
+    PipelineRunGuid = str(uuid.uuid4())
 TriggerGuid = format_guid(TriggerGuid)
 
 if not PipelineParentRunGuid:

--- a/src/PL_FMD_LOAD_BRONZE.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_BRONZE.DataPipeline/pipeline-content.json
@@ -337,7 +337,7 @@
                   },
                   "PipelineParentRunGuid": {
                     "value": {
-                      "value": "@pipeline()?.TriggeredByPipelineRunId",
+                      "value": "@if(empty(string(pipeline()?.TriggeredByPipelineRunId)), pipeline().RunId, pipeline()?.TriggeredByPipelineRunId)",
                       "type": "Expression"
                     },
                     "type": "string"

--- a/src/PL_FMD_LOAD_BRONZE.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_BRONZE.DataPipeline/pipeline-content.json
@@ -327,6 +327,20 @@
                       "type": "Expression"
                     },
                     "type": "string"
+                  },
+                  "PipelineRunGuid": {
+                    "value": {
+                      "value": "@pipeline().RunId",
+                      "type": "Expression"
+                    },
+                    "type": "string"
+                  },
+                  "PipelineParentRunGuid": {
+                    "value": {
+                      "value": "@pipeline()?.TriggeredByPipelineRunId",
+                      "type": "Expression"
+                    },
+                    "type": "string"
                   }
                 },
                 "sessionTag": "fmd_framework"

--- a/src/PL_FMD_LOAD_SILVER.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_SILVER.DataPipeline/pipeline-content.json
@@ -331,6 +331,20 @@
                       "type": "Expression"
                     },
                     "type": "string"
+                  },
+                  "PipelineRunGuid": {
+                    "value": {
+                      "value": "@pipeline().RunId",
+                      "type": "Expression"
+                    },
+                    "type": "string"
+                  },
+                  "PipelineParentRunGuid": {
+                    "value": {
+                      "value": "@pipeline()?.TriggeredByPipelineRunId",
+                      "type": "Expression"
+                    },
+                    "type": "string"
                   }
                 },
                 "sessionTag": "fmd_framework"


### PR DESCRIPTION
`logging.NotebookExecution.PipelineParentRunGuid` holds `00000000-0000-0000-0000-000000000000` on **every** row. A notebook run can never be correlated with the pipeline that started it, and the obvious monitoring query returns zero rows on every input, which reads exactly like *the load did no work*.

Three independent checks, all at `1ba7974`:

**1. The pipelines never pass a run id.** `PL_FMD_LOAD_BRONZE` and `PL_FMD_LOAD_SILVER` pass exactly four parameters to `NB_FMD_PROCESSING_PARALLEL_MAIN`: `Path`, `TriggerGuid`, `TriggerTime`, `TriggerType`.

**2. The runtime-context key does not exist.**

```python
PipelineParentRunGuid = notebookutils.runtime.context.get("PipelineParentRunGuid")   # line 158
```

Microsoft's property table for `notebookutils.runtime.context` lists 25 properties: `currentNotebookName`, `currentNotebookId`, `currentWorkspaceName`, `currentWorkspaceId`, `defaultLakehouse*`, `currentRunId`, `parentRunId`, `rootRunId`, `isForPipeline`, `isForInteractive`, `isReferenceRun`, `referenceTreePath`, `rootNotebook*`, `rootWorkspace*`, `activityId`, `hcReplId`, `clusterId`, `poolName`, `environmentId`, `environmentWorkspaceId`, `userId`, `userName`, `currentKernel`, `productType`.

**`PipelineParentRunGuid` is not among them.** The `.get()` returns `None` on every run, and the fallback on line 163 fires every time.

[NotebookUtils runtime context for Fabric](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-runtime#view-session-context)

**3. `PipelineRunGuid` is overwritten.**

```python
PipelineRunGuid = str(uuid.uuid4())   # line 159
```

So the notebook's other correlation column matches no pipeline row either. Both columns are real on `PipelineExecution` and `CopyActivityExecution`, which is what makes the mistake easy to walk into.

## The fix completes what the notebook already expects

The parameters cell **already declares** `PipelineRunGuid = ""`, so the design intended the pipeline to pass it. This PR:

- `PL_FMD_LOAD_BRONZE` and `PL_FMD_LOAD_SILVER` now pass `@pipeline().RunId` and `@pipeline()?.TriggeredByPipelineRunId` to the orchestrator, **exactly the expressions their own `sp_AuditPipeline` calls already bind**.
- `NB_FMD_PROCESSING_PARALLEL_MAIN` declares `PipelineParentRunGuid` in the parameters cell and uses both values instead of overwriting them. The `uuid4` remains as the fallback for an interactive run, and the runtime-context read remains as a second fallback, so nothing regresses.

After this, `NotebookExecution` joins to `PipelineExecution` on `PipelineParentRunGuid` the way the column name promises.

Found while deploying the framework end to end and writing a query to find out why a Silver load had failed.