### PR TITLE
Make HashedPKColumn independent of the source column order

### DIFF
--- a/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
@@ -414,7 +414,9 @@ for pk_column in key_columns:
         raise ValueError(f"PK: {pk_column} doesn't exist in the source.")
         # Define all the Non-Key columns => HashExcludeColumns
 
-read_key_columns = [column for column in dfDataChanged.columns if column in key_columns]
+# Order the key columns by PrimaryKeys, not by the source, so that the hash of a row
+# does not change when the source hands its columns over in a different order.
+read_key_columns = [column for column in key_columns if column in dfDataChanged.columns]
 
 # Add a column with the calculated hash, easier in later stage of with multiple PK
 dfDataChanged = (dfDataChanged

--- a/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
@@ -416,7 +416,8 @@ for pk_column in key_columns:
 
 # Order the key columns by PrimaryKeys, not by the source, so that the hash of a row
 # does not change when the source hands its columns over in a different order.
-read_key_columns = [column for column in key_columns if column in dfDataChanged.columns]
+# Also deduplicate while preserving order to avoid hashing the same PK column twice.
+read_key_columns = list(dict.fromkeys(key_columns))
 
 # Add a column with the calculated hash, easier in later stage of with multiple PK
 dfDataChanged = (dfDataChanged


### PR DESCRIPTION
`HashedPKColumn` is the identity of a row in the whole framework: Silver matches on it, SCD-2 closes and opens rows by it, and it is computed in exactly one place. It is currently **not stable against a reordering of the source columns**.

`NB_FMD_LOAD_LANDING_BRONZE` builds the list it hashes by walking the *dataframe*:

```python
read_key_columns = [column for column in dfDataChanged.columns if column in key_columns]

dfDataChanged = (dfDataChanged
                .withColumn("HashedPKColumn", sha2(concat_ws("||", *read_key_columns), 256)))
```

The membership test picks the right columns. The **order** comes from the source, not from `PrimaryKeys`. And `concat_ws` is order-sensitive.

```python
key_columns = ["CustomerId", "TenantId"]              # PrimaryKeys, from the metadata
row         = {"CustomerId": "42", "TenantId": "7", "Name": "Contoso"}

# same customer, two runs, source hands its columns over in a different order
["CustomerId", "TenantId", "Name"]   ->  concat over ['CustomerId', 'TenantId']  ->  b712cee5efa6de8a
["TenantId", "CustomerId", "Name"]   ->  concat over ['TenantId', 'CustomerId']  ->  5316797ca1300d0f
```

Same business key, two identities. Silver then finds no match for any row, closes every existing SCD-2 record and inserts the lot as new.

## The fix

Iterate over `key_columns`, so the order is fixed by the metadata rather than by whatever the source happens to emit:

```python
read_key_columns = [column for column in key_columns if column in dfDataChanged.columns]
```

The loop directly above already raises `PK: {pk_column} doesn't exist in the source.` if a key is missing, so the membership test here only guards the comprehension. **The selected set of columns is unchanged. Only the order is now defined.**

## Scope of the change

**Single-key entities are unaffected.** A one-element list has one ordering, so those hash identically before and after.

**Composite-key entities whose source column order differs from `PrimaryKeys` will hash differently after this change**, which for an existing deployment means Silver stops matching against rows written before it. Those entities need a Silver reload. That is unavoidable in any fix that makes the order deterministic, and the alternative is leaving the identity of a row dependent on the source's column order. If you would rather not depend on the metadata order either, `sorted(key_columns)` makes the hash a function of the *set* of key columns, which is arguably what a primary key is. I did not do that here because it is the larger behaviour change and the call is yours.

## On #236

**I have not reproduced #236 and I am not claiming this closes it.** The reporter sees a new `HashedPKColumn` on *every* run, and a SQL view does not normally reorder its columns between runs, so there may well be a second cause. What I can say is that this is one way the framework can produce a changing hash for an unchanged business key, it is provable from the code, and it is worth ruling out first. A reporter can check it in one line by printing `dfDataChanged.columns` and `key_columns` next to each other before the hash is computed: if the two orders disagree, and the source's order is not stable, this is the mechanism.

Found while documenting the framework at `1ba7974` and tracing what gives a row its identity.
