### PR TITLE
Landing zone: report failure instead of reporting success

### DIFF
--- a/src/PL_FMD_LDZ_COMMAND_ADF.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_ADF.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_ADLS.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_ADLS.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_ASQL.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_ASQL.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_FTP.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_FTP.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_NOTEBOOK.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_NOTEBOOK.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_ONELAKE.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_ONELAKE.DataPipeline/pipeline-content.json
@@ -495,6 +495,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_ORACLE.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_ORACLE.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_SFTP.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_SFTP.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COMMAND_SQLMI.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COMMAND_SQLMI.DataPipeline/pipeline-content.json
@@ -443,6 +443,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_ADF.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ADF.DataPipeline/pipeline-content.json
@@ -959,6 +959,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_ADLS_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ADLS_01.DataPipeline/pipeline-content.json
@@ -1005,6 +1005,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_ASQL_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ASQL_01.DataPipeline/pipeline-content.json
@@ -2149,6 +2149,44 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
+      },
+      {
+        "name": "FA_THROW_ERROR_1",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE_0",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_CUSTOM_NB.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_CUSTOM_NB.DataPipeline/pipeline-content.json
@@ -1018,6 +1018,25 @@
             ]
           }
         ]
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_FTP_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_FTP_01.DataPipeline/pipeline-content.json
@@ -1186,6 +1186,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_FILES_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_FILES_01.DataPipeline/pipeline-content.json
@@ -1012,6 +1012,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_TABLES_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_TABLES_01.DataPipeline/pipeline-content.json
@@ -1016,6 +1016,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_ORACLE_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ORACLE_01.DataPipeline/pipeline-content.json
@@ -1211,6 +1211,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_SFTP_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_SFTP_01.DataPipeline/pipeline-content.json
@@ -1184,6 +1184,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LDZ_COPY_FROM_SQLMI_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_SQLMI_01.DataPipeline/pipeline-content.json
@@ -1159,6 +1159,25 @@
             }
           }
         }
+      },
+      {
+        "name": "FA_THROW_ERROR",
+        "type": "Fail",
+        "dependsOn": [
+          {
+            "activity": "SP_FAIL_AUDIT_PIPELINE",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "typeProperties": {
+          "message": {
+            "value": "@concat('Landing zone failed in ', pipeline().PipelineName, '. See logging for pipeline run ', pipeline().RunId, '.')",
+            "type": "Expression"
+          },
+          "errorCode": "Landingzone failed"
+        }
       }
     ],
     "parameters": {


### PR DESCRIPTION
Follow-up to #250, which closed this gap in `PL_FMD_LOAD_ALL`. The same gap sits in all 19 landing-zone pipelines below it.

> **Revised.** The first version of this PR touched 11 pipelines and claimed `PL_FMD_LDZ_COPY_FROM_{FTP,SFTP}_01` had no inner catch. That was wrong: they do, one level deeper, inside `ForEach1 -> If Condition1`. The correction made the change simpler, not more complicated, because the two catches are at different levels and only one of them is the problem.

## Two catches, and only one of them is wrong

Every landing-zone pipeline has **two** failure paths, and they do different jobs:

| Activity | Where | Fires when | Today |
|---|---|---|---|
| `SP_FAIL_AUDIT_PIPELINE_CP` | **inside** the loop | the copy fails **for one entity** | logs, swallows, loop continues |
| `SP_FAIL_AUDIT_PIPELINE` | **top level**, on `<loop> : Failed` | the **loop itself** fails | logs, and then nothing |

The inner one is right, and this PR does not touch it. Swallowing one entity's failure is what keeps a single unreachable source from stopping the landing zone for every other entity. All 15 of those catches are left exactly as they are, and **no `Fail` activity is added inside any loop**.

The top-level one is the leak. It is a leaf, and a leaf that succeeds:

> | Approach | Defines | When activity **fails**, overall pipeline shows |
> |---|---|---|
> | Try-Catch | Only *Upon Failure* path | **Success** |
>
> [Errors and conditional execution](https://learn.microsoft.com/azure/data-factory/tutorial-pipeline-failure-error-handling#error-handling)

So the failure is written to `logging`, and the pipeline a parent or a scheduler watches reports success anyway.

## What this PR does

Adds `FA_THROW_ERROR` after each top-level catch, on `Completed`, exactly as `PL_FMD_LOAD_BRONZE` already does. Twenty in total: nineteen pipelines, and `PL_FMD_LDZ_COPY_FROM_ASQL_01` gets two because it has two loops. The audit row is still written before the throw, so `logging` loses nothing.

## The one that remains, and why I left it to you

A copy that fails **for a single entity** is still invisible above the audit table, because the inner catch handles it and the loop goes green. That is by design and this PR keeps it that way. But it does mean the failure I actually hit at `1ba7974` on a live tenant stays silent: `PL_FMD_LDZ_COPY_FROM_ONELAKE_TABLES_01` failed, `logging` recorded it, nothing was loaded, and every pipeline above it reported success.

If you want a run to end red when *any* entity failed, while keeping the loop resilient, the shape that does not fight a parallel `ForEach` is to ask the audit trail after the loop: a `Lookup` over `logging` for failures with this `RunId`, an `IfCondition`, and `FA_THROW_ERROR`. That is the same log-then-throw you already use, one level up. Happy to add it here or separately. It changes when a run is considered failed, so it is your call, not mine.

Found while deploying the framework at `1ba7974` end to end and asking why a run with an empty Bronze queue was still green.
