### PR TITLE
Give PL_FMD_LOAD_LANDINGZONE a failure audit activity

### DIFF
--- a/src/PL_FMD_LOAD_LANDINGZONE.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_LANDINGZONE.DataPipeline/pipeline-content.json
@@ -649,6 +649,126 @@
             ]
           }
         ]
+      },
+      {
+        "type": "SqlServerStoredProcedure",
+        "typeProperties": {
+          "storedProcedureName": {
+            "value": "[logging].[sp_AuditPipeline]",
+            "type": "Expression"
+          },
+          "storedProcedureParameters": {
+            "LogData": {
+              "value": {
+                "value": "{    \"Action\" : \"Error\",     \"Message\" : \"LDZ failed\"}",
+                "type": "Expression"
+              },
+              "type": "String"
+            },
+            "LogType": {
+              "value": "FailPipeline",
+              "type": "String"
+            },
+            "PipelineGuid": {
+              "value": {
+                "value": "@pipeline().Pipeline",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "PipelineName": {
+              "value": {
+                "value": "@pipeline().PipelineName",
+                "type": "Expression"
+              },
+              "type": "String"
+            },
+            "PipelineParameters": {
+              "value": null,
+              "type": "String"
+            },
+            "PipelineParentRunGuid": {
+              "value": {
+                "value": "@pipeline()?.TriggeredByPipelineRunId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "PipelineRunGuid": {
+              "value": {
+                "value": "@pipeline().RunId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "TriggerGuid": {
+              "value": {
+                "value": "@pipeline().TriggerId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "TriggerTime": {
+              "value": {
+                "value": "@pipeline().TriggerTime",
+                "type": "Expression"
+              },
+              "type": "DateTime"
+            },
+            "TriggerType": {
+              "value": {
+                "value": "@pipeline().TriggerType",
+                "type": "Expression"
+              },
+              "type": "String"
+            },
+            "WorkspaceGuid": {
+              "value": {
+                "value": "@pipeline().DataFactory",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "EntityLayer": {
+              "value": "Landingzone",
+              "type": "String"
+            },
+            "EntityId": {
+              "value": null,
+              "type": "Int32"
+            }
+          }
+        },
+        "connectionSettings": {
+          "name": "SQL_FMD_FRAMEWORK",
+          "properties": {
+            "type": "FabricSqlDatabase",
+            "typeProperties": {
+              "artifactId": "@pipeline().libraryVariables.VAR_CONFIG_FMD_fmd_config_database_guid",
+              "workspaceId": "@pipeline().libraryVariables.VAR_CONFIG_FMD_fmd_config_workspace_guid"
+            },
+            "externalReferences": {
+              "connection": "372237f9-709a-48f8-8fb2-ce06940c990e"
+            },
+            "annotations": []
+          }
+        },
+        "policy": {
+          "timeout": "0.01:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureInput": false,
+          "secureOutput": false
+        },
+        "name": "SP_FAIL_AUDIT_PIPELINE",
+        "dependsOn": [
+          {
+            "activity": "FE_ENTITY",
+            "dependencyConditions": [
+              "Failed"
+            ]
+          }
+        ]
       }
     ],
     "parameters": {

--- a/src/PL_FMD_LOAD_LANDINGZONE.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_LANDINGZONE.DataPipeline/pipeline-content.json
@@ -660,7 +660,7 @@
           "storedProcedureParameters": {
             "LogData": {
               "value": {
-                "value": "{    \"Action\" : \"Error\",     \"Message\" : \"LDZ failed\"}",
+                "value": "{ \"Action\" : \"Error\", \"Message\" : \"LDZ failed\", \"Error\" : @{activity('FE_ENTITY').error}}",
                 "type": "Expression"
               },
               "type": "String"


### PR DESCRIPTION
`PL_FMD_LOAD_LANDINGZONE` has two audit activities and no failure one:

| Activity | dependsOn |
|---|---|
| `SP_START_AUDIT_PIPELINE` | — |
| `LK_GET_ENTITIES` | `SP_START_AUDIT_PIPELINE: Succeeded` |
| `FE_ENTITY` | `LK_GET_ENTITIES: Succeeded` |
| `SP_END_AUDIT_PIPELINE` | `FE_ENTITY: **Succeeded**` |

There is no `SP_FAIL_*` at any depth.

**Every sibling has one.** `PL_FMD_LOAD_BRONZE` and `PL_FMD_LOAD_SILVER` each have `SP_FAIL_AUDIT_PIPELINE`. All nine `PL_FMD_LDZ_COMMAND_*` have one. All ten `PL_FMD_LDZ_COPY_FROM_*` have `SP_FAIL_AUDIT_PIPELINE_CP` inside the loop. The landing zone is the only one without.

## What it costs

When the landing zone fails it writes **no failure row at all**. Its only signature in `logging` is an *absence*: a `StartPipeline` row with no matching `EndPipeline`.

That matters more here than it would elsewhere, because `logging` is the only reliable failure signal the framework has. `PL_FMD_LOAD_ALL` reports Success when a layer fails (#250), and the landing-zone pipelines swallow their own failures (#253). So the audit trail is what an operator reads after a bad night, and the layer that failed is the one layer that cannot say so.

Observed at `1ba7974` on a live tenant. `PL_FMD_LOAD_LANDINGZONE` ran for 32m53s, came back `Failed`, and `logging.PipelineExecution` contains no row for it:

```
11:05:25  PL_FMD_LOAD_ALL      StartPipeline
11:38:30  PL_FMD_LOAD_ALL      FailedPipeline   { "Action": "Error", "Message": "BRZ failed" }
11:38:46  PL_FMD_LOAD_BRONZE   StartPipeline
11:39:06  PL_FMD_LOAD_BRONZE   EndPipeline      (empty queue)
```

(The `BRZ failed` on a landing-zone failure is #255.)

## This PR

Adds `SP_FAIL_AUDIT_PIPELINE` on `FE_ENTITY: Failed`, copied from the sibling in `PL_FMD_LOAD_BRONZE`, with `EntityLayer` set to `Landingzone` and the message to `LDZ failed`. No existing activity or dependency is touched.

## One thing I noticed while copying the sibling, and left alone

The three layer pipelines each spell a pipeline failure differently:

| Pipeline | `LogType` it writes on failure |
|---|---|
| `PL_FMD_LOAD_BRONZE` | `FailPipeline` |
| `PL_FMD_LOAD_SILVER` | `FailPipelineActivity` |
| `PL_FMD_LOAD_ALL` | `FailedPipeline` |

A monitoring query filtering `LogType = 'FailedPipeline'` therefore sees the orchestrator's failures and never Bronze's or Silver's. `LIKE 'Fail%'` catches all three. I have used `FailPipeline` here, to match `PL_FMD_LOAD_BRONZE`, rather than pick a fourth. If you would rather they were unified, say so and I will do that in a separate PR.

Found while writing an operational runbook against the framework at `1ba7974`.
