### PR TITLE
Fix the StartCopyAcitvity typo, which makes ADLS and ADF invisible to a copy query

### DIFF
--- a/src/PL_FMD_LDZ_COPY_FROM_ADF.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ADF.DataPipeline/pipeline-content.json
@@ -43,7 +43,7 @@
                     "type": "String"
                   },
                   "LogType": {
-                    "value": "StartCopyAcitvity",
+                    "value": "StartCopyActivity",
                     "type": "String"
                   },
                   "PipelineGuid": {

--- a/src/PL_FMD_LDZ_COPY_FROM_ADLS_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ADLS_01.DataPipeline/pipeline-content.json
@@ -137,7 +137,7 @@
                     "type": "String"
                   },
                   "LogType": {
-                    "value": "StartCopyAcitvity",
+                    "value": "StartCopyActivity",
                     "type": "String"
                   },
                   "PipelineGuid": {


### PR DESCRIPTION
Two of the ten copy pipelines spell their own audit event differently:

```
$ grep -rho "StartCopyA[a-z]*" src/*.DataPipeline/pipeline-content.json | sort | uniq -c
      2 StartCopyAcitvity      <- PL_FMD_LDZ_COPY_FROM_ADLS_01, PL_FMD_LDZ_COPY_FROM_ADF
      9 StartCopyActivity
```

`Acitvity`. The `t` and the `v` are transposed.

## What it costs

Nothing breaks. The row is written, the pipeline runs, the data lands. But a query like

```sql
SELECT * FROM logging.CopyActivityExecution WHERE LogType = 'StartCopyActivity'
```

**silently omits every ADLS and every ADF copy**, on every run, forever. The rows exist under a name nobody would think to ask for.

That matters more than a cosmetic typo would, because the copy-activity log is the only place a per-entity copy failure lands: the failure is caught inside the `ForEach` and never propagates upward. An operator building a monitoring query against `CopyActivityExecution` will get a complete-looking answer that has two source families missing from it.

I hit this while writing an operational query and finding that an ADLS entity never appeared in it.

## This PR

Replaces `StartCopyAcitvity` with `StartCopyActivity` in the two pipelines. Nothing else changes.

**One thing to decide, and it is yours.** If any deployment already has rows under the old spelling, this changes the value that new rows carry, and a query would need `LogType LIKE 'StartCopyA%'` to see both. It is two rows-worth of history in the two affected pipelines, so I think the fix is worth it, but you know your users' dashboards better than I do.
