### PR TITLE
Purview lineage: point Data_WorkspaceGuid at the placeholder the setup already substitutes

### DIFF
--- a/src/NB_FMD_FABRIC_PURVIEW_LINEAGE_TABLE_COLUMN_EXTRACTOR.Notebook/notebook-content.py
+++ b/src/NB_FMD_FABRIC_PURVIEW_LINEAGE_TABLE_COLUMN_EXTRACTOR.Notebook/notebook-content.py
@@ -140,7 +140,7 @@ database=config_settings.fmd_fabric_db_name
 
 # PARAMETERS CELL ********************
 
-SourceWorkspaceId="3e43b742-3e41-4ec0-a414-03adf83c08e7"
+SourceWorkspaceId="00000000-0000-0000-0000-000000000000"
 
 # METADATA ********************
 

--- a/src/PL_FMD_TOOLING_LOAD_TO_PURVIEW.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_TOOLING_LOAD_TO_PURVIEW.DataPipeline/pipeline-content.json
@@ -30,7 +30,7 @@
     "parameters": {
       "Data_WorkspaceGuid": {
         "type": "string",
-        "defaultValue": "3e43b742-3e41-4ec0-a414-03adf83c08e7"
+        "defaultValue": "40e27fdc-775a-4ee2-84d5-48893c92d7cc"
       }
     },
     "libraryVariables": {


### PR DESCRIPTION
## The mechanism

The setup's GUID substitution works, and it works well. `deploy_item` calls `replace_ids_and_mark_inactive` for every DataPipeline, which rewrites every `old_id` found in `mapping_table`, and `mapping_table` is built from `config/item_config.yaml`. I checked it against a live deployment: `PL_FMD_LOAD_ALL`'s `Data_WorkspaceGuid` default arrives in the target tenant already rewritten to the deployer's own data workspace. That is a nice piece of design and it needs no change.

**One pipeline sits outside it.** `PL_FMD_TOOLING_LOAD_TO_PURVIEW` declares a `Data_WorkspaceGuid` parameter, the same name every other pipeline uses, but defaults it to a different GUID:

| Pipeline | `Data_WorkspaceGuid` default | In `item_config.yaml`? | Substituted at deploy? |
|---|---|---|---|
| `PL_FMD_LOAD_ALL` | `40e27fdc-…` | yes, `workspaces.workspace_data` | **yes** |
| `PL_FMD_LOAD_LANDINGZONE` | `40e27fdc-…` | yes | **yes** |
| `PL_TOOLING_POST_ASQL_TO_FMD` | `40e27fdc-…` | yes | **yes** |
| `PL_FMD_TOOLING_LOAD_TO_PURVIEW` | `3e43b742-…` | **no** | **no** |

`3e43b742-3e41-4ec0-a414-03adf83c08e7` appears in no mapping, so `content.replace()` never sees it and it survives deployment unchanged. Run the Purview tooling without overriding the parameter by hand and it pushes lineage for a workspace GUID that belongs to your tenant only by accident.

## The change

Point it at the same placeholder the other three use, so your existing substitution handles it:

```diff
-        "defaultValue": "3e43b742-3e41-4ec0-a414-03adf83c08e7"
+        "defaultValue": "40e27fdc-775a-4ee2-84d5-48893c92d7cc"
```

And in `NB_FMD_FABRIC_PURVIEW_LINEAGE_TABLE_COLUMN_EXTRACTOR`, the same orphaned GUID is the `SourceWorkspaceId` default in the parameters cell. Notebooks are imported without ID substitution, and the pipeline passes `SourceWorkspaceId` as an activity parameter, so that cell value only matters for a standalone run. Set to the all-zeros GUID, it reads as the placeholder it is rather than as a real workspace.

No behaviour changes for anyone who was already overriding the parameter.

Found while writing external documentation for FMD. Verified against `1ba7974` and against a live deployment.