### PR TITLE
Do not ship the maintainer's database principals into an adopter's tenant

### DIFF
--- a/src/Config_Database/Security/db_owner for floris@edkreukmsn.onmicrosoft.com.sql
+++ b/src/Config_Database/Security/db_owner for floris@edkreukmsn.onmicrosoft.com.sql
@@ -1,5 +1,0 @@
-ALTER ROLE [db_owner] ADD MEMBER [floris@edkreukmsn.onmicrosoft.com];
-
-
-GO
-

--- a/src/Config_Database/Security/erwin@edkreukmsn.onmicrosoft.com.sql
+++ b/src/Config_Database/Security/erwin@edkreukmsn.onmicrosoft.com.sql
@@ -1,6 +1,0 @@
-CREATE USER [erwin@edkreukmsn.onmicrosoft.com]
-    WITH SID = 0x3355C3455A94FB41A9F004CE5FD53A07, TYPE = E;
-
-
-GO
-

--- a/src/Config_Database/Security/execution.sql
+++ b/src/Config_Database/Security/execution.sql
@@ -1,5 +1,5 @@
 CREATE SCHEMA [execution]
-    AUTHORIZATION [erwin@edkreukmsn.onmicrosoft.com];
+    AUTHORIZATION [dbo];
 
 
 GO

--- a/src/Config_Database/Security/floris@edkreukmsn.onmicrosoft.com.sql
+++ b/src/Config_Database/Security/floris@edkreukmsn.onmicrosoft.com.sql
@@ -1,6 +1,0 @@
-CREATE USER [floris@edkreukmsn.onmicrosoft.com]
-    WITH SID = 0xF3A1539C8C2A8D45A82F3A6CADAA5B9A, TYPE = E;
-
-
-GO
-

--- a/src/Config_Database/Security/integration.sql
+++ b/src/Config_Database/Security/integration.sql
@@ -1,5 +1,5 @@
 CREATE SCHEMA [integration]
-    AUTHORIZATION [erwin@edkreukmsn.onmicrosoft.com];
+    AUTHORIZATION [dbo];
 
 
 GO

--- a/src/Config_Database/Security/logging.sql
+++ b/src/Config_Database/Security/logging.sql
@@ -1,5 +1,5 @@
 CREATE SCHEMA [logging]
-    AUTHORIZATION [erwin@edkreukmsn.onmicrosoft.com];
+    AUTHORIZATION [dbo];
 
 
 GO


### PR DESCRIPTION
## What happens today

`src/Config_Database/Security/` holds six files. Three of them name principals from the `edkreukmsn` tenant:

```sql
CREATE USER [erwin@edkreukmsn.onmicrosoft.com]  WITH SID = 0x3355C3..., TYPE = E;
CREATE USER [floris@edkreukmsn.onmicrosoft.com] WITH SID = 0xF3A153..., TYPE = E;
ALTER ROLE  [db_owner] ADD MEMBER [floris@edkreukmsn.onmicrosoft.com];
```

and the other three authorize the schemas to one of them:

```sql
CREATE SCHEMA [integration] AUTHORIZATION [erwin@edkreukmsn.onmicrosoft.com];   -- same for execution, logging
```

These are not inert project files. They are in `src/SQL_FMD_FRAMEWORK.SQLDatabase/SQL_FMD_FRAMEWORK.dacpac`, and that dacpac is the item definition `NB_SETUP_FMD` imports. So they deploy.

## Verified against a live deployment

Deployed FMD into an unrelated tenant and asked the configuration database:

```
sys.database_principals
    erwin@edkreukmsn.onmicrosoft.com     EXTERNAL_USER   EXTERNAL
    floris@edkreukmsn.onmicrosoft.com    EXTERNAL_USER   EXTERNAL

sys.schemas
    integration   owned by  erwin@edkreukmsn.onmicrosoft.com
    execution     owned by  erwin@edkreukmsn.onmicrosoft.com
    logging       owned by  erwin@edkreukmsn.onmicrosoft.com

db_owner  <-  floris@edkreukmsn.onmicrosoft.com
```

## What it does and does not mean

Being accurate about the severity, because it is easy to overstate.

**It is not exploitable as it stands.** An `EXTERNAL_USER` carrying a SID from another tenant cannot authenticate unless that identity also exists in the deploying tenant's directory. Nobody is getting into anybody's database today.

**What it does cost the adopter is real, though:**

- Three schemas in their configuration database are owned by a principal that does not exist in their directory. Ownership by an unresolvable principal is awkward to reason about and the user cannot be dropped while it owns schemas.
- If either identity is ever invited into the tenant as a guest, and inviting a framework's maintainer is not far-fetched, `floris@` holds `db_owner` on the configuration database from that moment, without anyone granting it.
- A security review of the deployment will find two foreign external users and stop there.

## The change

Remove the two `CREATE USER` statements and the `db_owner` membership, and authorize the three schemas to `dbo`:

```diff
-CREATE SCHEMA [integration] AUTHORIZATION [erwin@edkreukmsn.onmicrosoft.com];
+CREATE SCHEMA [integration] AUTHORIZATION [dbo];
```

Six files, three deletions, three one-line edits. Nothing in the framework references either principal: the notebooks and pipelines authenticate as the workspace identity or as the connection's own credential, so no runtime path depends on these users.

Almost certainly this is SSDT having captured the state of the database it was reverse-engineered from, rather than anything intended.

## One thing to check on your side

**The dacpac is what deploys, and this PR changes only the project sources.** `src/SQL_FMD_FRAMEWORK.SQLDatabase/` contains nothing but `SQL_FMD_FRAMEWORK.dacpac`, and `deploy_item` imports that folder; the `.sql` files under `src/Config_Database/` are the sources of `SQL_FMD_FRAMEWORK.sqlproj` that builds it. So the fix reaches a deployment only once the dacpac is rebuilt from the project, and that is a build I would rather you ran than accept as a binary diff from a stranger.

While you are there: a build step that rebuilds the dacpac on any change under `src/Config_Database/` would stop the two drifting. Happy to open that separately if it would help.

Found while writing external documentation for FMD. Verified against `1ba7974` and against a live deployment.