### PR TITLE
Give PL_FMD_LOAD_SILVER the same PipelineParentRunGuid fallback as Bronze

### DIFF
--- a/src/PL_FMD_LOAD_SILVER.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LOAD_SILVER.DataPipeline/pipeline-content.json
@@ -341,7 +341,7 @@
                   },
                   "PipelineParentRunGuid": {
                     "value": {
-                      "value": "@pipeline()?.TriggeredByPipelineRunId",
+                      "value": "@if(empty(string(pipeline()?.TriggeredByPipelineRunId)), pipeline().RunId, pipeline()?.TriggeredByPipelineRunId)",
                       "type": "Expression"
                     },
                     "type": "string"


### PR DESCRIPTION
## What

Give the Silver layer's notebook activity the same `PipelineParentRunGuid` fallback that the Bronze layer already has.

`PL_FMD_LOAD_BRONZE` passes the notebook:

```
PipelineParentRunGuid = @if(empty(string(pipeline()?.TriggeredByPipelineRunId)), pipeline().RunId, pipeline()?.TriggeredByPipelineRunId)
```

`PL_FMD_LOAD_SILVER` passed the bare:

```
PipelineParentRunGuid = @pipeline()?.TriggeredByPipelineRunId
```

This PR changes the one Silver expression to match Bronze. One line in `PL_FMD_LOAD_SILVER.DataPipeline/pipeline-content.json`.

## Why

Under `InvokePipeline`, `pipeline()?.TriggeredByPipelineRunId` resolves to NULL, so the Silver notebook records `PipelineParentRunGuid = 00000000-0000-0000-0000-000000000000` on every `logging.NotebookExecution` row, while the Bronze notebook records a real GUID. The two layers log the same column differently.

An all-zeros `PipelineParentRunGuid` on the Silver rows reads, at a glance, like the Silver load recorded nothing, which sends a reader looking upstream for a failure that is not there.

## Measured

On a deployment carrying this repo's current `main`, the `customer` entity was run through Bronze then Silver, reading `logging.NotebookExecution`:

| Notebook row | `PipelineRunGuid` | `PipelineParentRunGuid` |
|---|---|---|
| Bronze (`NB_FMD_LOAD_LANDING_BRONZE`) | Bronze pipeline `RunId` | same GUID (real) |
| Silver (`NB_FMD_LOAD_BRONZE_SILVER`) | Silver pipeline `RunId` | `00000000-0000-0000-0000-000000000000` |

After this change, the Silver notebook row records its own `RunId` in `PipelineParentRunGuid`, matching Bronze.

## Scope, stated plainly

This brings the two layers into agreement and removes the all-zeros value. It does **not** make `PipelineParentRunGuid` point at the pipeline that invoked the layer (`PL_FMD_LOAD_ALL`): under `InvokePipeline`, `TriggeredByPipelineRunId` is NULL for both layers, so the fallback records the layer pipeline's own `RunId`, the same value already in `PipelineRunGuid`. The reliable join from a notebook row to its layer pipeline is `PipelineRunGuid`, which equals the layer pipeline's `RunId` on both layers.

## Deploying

This changes a `DataPipeline` item, so it takes effect when `PL_FMD_LOAD_SILVER` is redeployed. No SQL object or dacpac is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
