### PR TITLE
Serialize the watermark advance after the queue insert (fixes #258)

### DIFF
--- a/src/PL_FMD_LDZ_COPY_FROM_ADF.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ADF.DataPipeline/pipeline-content.json
@@ -139,12 +139,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -511,7 +505,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "PL_INVOKE_ADF",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]

--- a/src/PL_FMD_LDZ_COPY_FROM_ADLS_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ADLS_01.DataPipeline/pipeline-content.json
@@ -236,12 +236,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -557,7 +551,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "CP_source_datalandingzone",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]

--- a/src/PL_FMD_LDZ_COPY_FROM_ASQL_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ASQL_01.DataPipeline/pipeline-content.json
@@ -246,12 +246,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -737,7 +731,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "CP_source_datalandingzone",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]

--- a/src/PL_FMD_LDZ_COPY_FROM_CUSTOM_NB.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_CUSTOM_NB.DataPipeline/pipeline-content.json
@@ -247,12 +247,6 @@
               "name": "SP_END_AUDIT_PIPELINE_CP",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -494,7 +488,7 @@
               "name": "SP_UPDATE_LASTLOADVALIE",
               "dependsOn": [
                 {
-                  "activity": "NB_FMD_PROCESSING_LANDINGZONE_MAIN",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]

--- a/src/PL_FMD_LDZ_COPY_FROM_FTP_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_FTP_01.DataPipeline/pipeline-content.json
@@ -413,12 +413,6 @@
                     "type": "SqlServerStoredProcedure",
                     "dependsOn": [
                       {
-                        "activity": "SP_UPDATE_PROCESS",
-                        "dependencyConditions": [
-                          "Succeeded"
-                        ]
-                      },
-                      {
                         "activity": "SP_UPDATE_LASTLOADVALIE",
                         "dependencyConditions": [
                           "Succeeded"
@@ -734,7 +728,7 @@
                     "type": "SqlServerStoredProcedure",
                     "dependsOn": [
                       {
-                        "activity": "CP_source_datalandingzone",
+                        "activity": "SP_UPDATE_PROCESS",
                         "dependencyConditions": [
                           "Succeeded"
                         ]

--- a/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_FILES_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_FILES_01.DataPipeline/pipeline-content.json
@@ -124,12 +124,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -445,7 +439,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "CP_source_datalandingzone",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]

--- a/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_TABLES_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ONELAKE_TABLES_01.DataPipeline/pipeline-content.json
@@ -247,12 +247,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -568,7 +562,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "CP_SOURCE_datalandingzone",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]

--- a/src/PL_FMD_LDZ_COPY_FROM_ORACLE_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ORACLE_01.DataPipeline/pipeline-content.json
@@ -235,12 +235,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -729,7 +723,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "CP_source_datalandingzone",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]

--- a/src/PL_FMD_LDZ_COPY_FROM_SFTP_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_SFTP_01.DataPipeline/pipeline-content.json
@@ -412,12 +412,6 @@
                     "type": "SqlServerStoredProcedure",
                     "dependsOn": [
                       {
-                        "activity": "SP_UPDATE_PROCESS",
-                        "dependencyConditions": [
-                          "Succeeded"
-                        ]
-                      },
-                      {
                         "activity": "SP_UPDATE_LASTLOADVALIE",
                         "dependencyConditions": [
                           "Succeeded"
@@ -733,7 +727,7 @@
                     "type": "SqlServerStoredProcedure",
                     "dependsOn": [
                       {
-                        "activity": "CP_source_datalandingzone",
+                        "activity": "SP_UPDATE_PROCESS",
                         "dependencyConditions": [
                           "Succeeded"
                         ]

--- a/src/PL_FMD_LDZ_COPY_FROM_SQLMI_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_SQLMI_01.DataPipeline/pipeline-content.json
@@ -229,12 +229,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE",
                   "dependencyConditions": [
                     "Succeeded"
@@ -711,7 +705,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "CP_source_datalandingzone",
+                  "activity": "SP_UPDATE_PROCESS",
                   "dependencyConditions": [
                     "Succeeded"
                   ]


### PR DESCRIPTION
Fixes #258. This is the ordering change from option 1 of the issue, matching the graph you showed.

## What

In every landing-zone copy pipeline, inside `FE_ENTITY`:

- `SP_UPDATE_PROCESS` queues the landed file for Bronze.
- `SP_UPDATE_LASTLOADVALIE` advances the watermark.

They both hung off the load activity (`CP_source_datalandingzone`, or `PL_INVOKE_ADF` / `NB_FMD_PROCESSING_LANDINGZONE_MAIN`) as **parallel siblings**, with no ordering between them and no shared transaction.

This PR serializes them:

- `SP_UPDATE_LASTLOADVALIE` now depends on `SP_UPDATE_PROCESS: Succeeded`.
- `SP_END_AUDIT_PIPELINE_CP` now depends on `SP_UPDATE_LASTLOADVALIE` alone (`SP_UPDATE_PROCESS` is a transitive predecessor), so the graph is the linear chain you drew.

```
CP_source_datalandingzone ─✓─▶ SP_UPDATE_PROCESS ─✓─▶ SP_UPDATE_LASTLOADVALIE ─✓─▶ SP_END_AUDIT_PIPELINE_CP
```

## Why

If the two siblings split (one succeeds, the other exhausts its retries under sustained `HTTP 430 Too many requests for capacity`), and the **watermark advances while the queue insert does not**, the landed file is never queued for Bronze, and the next incremental run's `WHERE <IsIncrementalColumn> > <LoadValue>` has already moved past those rows. The delta is lost and never fetched again.

With the ordering, the watermark can only advance after the file is queued. If the queue insert fails, the watermark stays put and the delta is re-fetched on the next run. The existing `retry: 2` policies still do exactly what they did; this removes the one loss direction they cannot cover, because a retry reduces the probability of the split but does not remove it (the two activities retry independently).

## Scope

Applied uniformly to all 10 copy pipelines: `ADF`, `ADLS_01`, `ASQL_01`, `CUSTOM_NB`, `FTP_01`, `ONELAKE_FILES_01`, `ONELAKE_TABLES_01`, `ORACLE_01`, `SFTP_01`, `SQLMI_01`. Two dependency edits each, no other change. These are `DataPipeline` items, so the change takes effect when the pipelines are redeployed; no SQL object or dacpac is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
