### PR TITLE
Fix missing variables in NB_SETUP_BUSINESS_DOMAINS.ipynb

### DIFF
--- a/setup/NB_SETUP_BUSINESS_DOMAINS.ipynb
+++ b/setup/NB_SETUP_BUSINESS_DOMAINS.ipynb
@@ -102,12 +102,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "key_vault_uri_name='val_key_vault_uri_name'\n",
-    "key_vault_tenant_id='val_key_vault_tenant_id'\n",
-    "key_vault_client_id='val_key_vault_client_id'\n",
-    "key_vault_client_secret='val_key_vault_client_secret'"
-   ]
+   "source": "key_vault_uri_name='val_key_vault_uri_name'\nkey_vault_tenant_id='val_key_vault_tenant_id'\nkey_vault_client_id='val_key_vault_client_id'\nkey_vault_client_secret='val_key_vault_client_secret'\npurview_account_name='val_purview_account_name'"
   },
   {
    "cell_type": "code",
@@ -793,16 +788,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "variable_parameters.update ( {\n",
-    "     \"SourceWorkspaceId\": SourceWorkspaceId,\n",
-    "      \"SourceLakehouseId\": SourceLakehouseId,\n",
-    "       \"SourceSchema\": SourceSchema,\n",
-    "        \"Shortcut_TargetSchema\": Shortcut_TargetSchema,\n",
-    "         \"Shortcut_TargetWorkspaceId\": Shortcut_TargetWorkspaceId,\n",
-    "          \"Shortcut_TargetLakehouseId\": Shortcut_TargetLakehouseId,\n",
-    "})"
-   ]
+   "source": "variable_parameters.update ( {\n     \"SourceWorkspaceId\": SourceWorkspaceId,\n      \"SourceLakehouseId\": SourceLakehouseId,\n       \"SourceSchema\": SourceSchema,\n        \"Shortcut_TargetSchema\": Shortcut_TargetSchema,\n         \"Shortcut_TargetWorkspaceId\": Shortcut_TargetWorkspaceId,\n          \"Shortcut_TargetLakehouseId\": Shortcut_TargetLakehouseId,\n          \"key_vault_tenant_id\": key_vault_tenant_id,\n          \"key_vault_client_id\": key_vault_client_id,\n          \"key_vault_client_secret\": key_vault_client_secret,\n})"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
NB_UTILITIES_SETUP_FMD expects purview_account_name and forwards key_vault_tenant_id/client_id/client_secret through variable_parameters when deploying VariableLibrary items, but the business domain setup notebook never defined/forwarded them, causing NameError and KeyError failures during a first-time deployment.