### PR TITLE
Serialize the ASQL_02 volume-split group too (follow-up to #271, #258)

### DIFF
--- a/src/PL_FMD_LDZ_COPY_FROM_ASQL_01.DataPipeline/pipeline-content.json
+++ b/src/PL_FMD_LDZ_COPY_FROM_ASQL_01.DataPipeline/pipeline-content.json
@@ -1369,12 +1369,6 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "SP_UPDATE_PROCESS_ASQL_02",
-                  "dependencyConditions": [
-                    "Succeeded"
-                  ]
-                },
-                {
                   "activity": "SP_UPDATE_LASTLOADVALIE_ASQL_02",
                   "dependencyConditions": [
                     "Succeeded"
@@ -1860,7 +1854,7 @@
               "type": "SqlServerStoredProcedure",
               "dependsOn": [
                 {
-                  "activity": "CP_source_datalandingzone_ASQL_02",
+                  "activity": "SP_UPDATE_PROCESS_ASQL_02",
                   "dependencyConditions": [
                     "Succeeded"
                   ]


### PR DESCRIPTION
Follow-up to #271, completing the fix for #258.

## What

#271 serialized the watermark advance behind the queue insert in the landing-zone copy pipelines. `PL_FMD_LDZ_COPY_FROM_ASQL_01` carries a second, volume-split source group (`FE_ENTITY_ASQL_02`) that #271 did not touch: at current `main`, `SP_UPDATE_PROCESS_ASQL_02` and `SP_UPDATE_LASTLOADVALIE_ASQL_02` both still hang off `CP_source_datalandingzone_ASQL_02` in parallel, the pre-#271 shape.

This applies the same ordering to the `_02` group:

- `SP_UPDATE_LASTLOADVALIE_ASQL_02` now `dependsOn SP_UPDATE_PROCESS_ASQL_02: Succeeded`.
- `SP_END_AUDIT_PIPELINE_CP_ASQL_02` now `dependsOn SP_UPDATE_LASTLOADVALIE_ASQL_02` alone (`SP_UPDATE_PROCESS_ASQL_02` is a transitive predecessor), matching the canonical group's linear chain.

## Why

Any entity assigned to the `ASQL_02` slot keeps the lost-delta exposure from #258: under sustained `HTTP 430` throttling the watermark could advance while the queue insert failed, and the delta is never queued and never re-fetched. With this change the watermark for that group can only advance after the file is queued, same as the canonical group.

One file, `PL_FMD_LDZ_COPY_FROM_ASQL_01.DataPipeline`, two dependency edits. It is a `DataPipeline` item, so it takes effect when the pipeline is redeployed; no SQL object or dacpac is involved. Found while re-checking the framework against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
