### PR TITLE
Restore the notebook error-audit call broken by #191

### DIFF
--- a/src/NB_FMD_LOAD_BRONZE_SILVER.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_BRONZE_SILVER.Notebook/notebook-content.py
@@ -661,7 +661,7 @@ except Exception as e:
     # Ensure audit log is written even on failure
     error_data = {"Action": "Error", "ErrorMessage": str(e)[:500]}
     try:
-        execute_with_outputs(EndNotebookActivity, driver, connstring, database, LogData=json.dumps(error_data))
+        execute_with_outputs(SP_AUDIT_NOTEBOOK, driver, connstring, database, **audit_params, LogData=json.dumps(error_data), LogType="EndNotebookActivity")
 
     except Exception as audit_error:
         print(f"Audit logging failed: {audit_error}")  # best-effort audit logging

--- a/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
+++ b/src/NB_FMD_LOAD_LANDING_BRONZE.Notebook/notebook-content.py
@@ -566,7 +566,7 @@ except Exception as e:
     # Ensure audit log is written even on failure
     error_data = {"Action": "Error", "ErrorMessage": str(e)[:500]}
     try:
-        execute_with_outputs(EndNotebookActivity, driver, connstring, database, LogData=json.dumps(error_data))
+        execute_with_outputs(SP_AUDIT_NOTEBOOK, driver, connstring, database, **audit_params, LogData=json.dumps(error_data), LogType="EndNotebookActivity")
     except Exception as audit_log_error:
         print(f"Audit logging failed: {audit_log_error}")  # best-effort audit logging
 


### PR DESCRIPTION
Follow-up to #191.

## What

#191 switched the notebook audit calls from a pre-built EXEC-string variable (`EndNotebookActivity = (...)`) to `execute_with_outputs(SP_AUDIT_NOTEBOOK, ..., LogType="EndNotebookActivity")` and removed the variable. It updated the three success-path calls but not the one in the `except` block of the two loader notebooks, which still reads:

```python
execute_with_outputs(EndNotebookActivity, driver, connstring, database, LogData=json.dumps(error_data))
```

`EndNotebookActivity` is no longer defined, so this line raises `NameError`.

## Why it matters

When a notebook fails **inside the `try`** (a Bronze or Silver write error), the `except` handler builds the error payload and tries to write the Error audit row. That call raises `NameError` before it can run; the inner best-effort `except` swallows it, the original error is re-raised, and `logging.NotebookExecution` ends up with a `Start` row but no `Error` row. The failure is real, but the audit trail records no error for it.

## The fix

Restore the call to the same parameterized form as the success path, with the error payload, in `NB_FMD_LOAD_LANDING_BRONZE` and `NB_FMD_LOAD_BRONZE_SILVER`:

```python
execute_with_outputs(SP_AUDIT_NOTEBOOK, driver, connstring, database, **audit_params, LogData=json.dumps(error_data), LogType="EndNotebookActivity")
```

Two lines, one per loader notebook. These are `Notebook` items, effective on redeploy; no SQL object or dacpac is involved. Found while re-checking the framework against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
